### PR TITLE
Feat: Add ignored directories setting

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -136,6 +136,16 @@ export class Cache {
         const doc = Text.of(fileLines);
         const path = file.path;
 
+        if (this.settings.ignoredDirectories) {
+            for (let ignoredDirectory of this.settings.ignoredDirectories.split(
+                ",",
+            )) {
+                if (path.includes(ignoredDirectory.trim())) {
+                    return;
+                }
+            }
+        }
+
         this.removeCurrentPathFromAllMentions(path);
 
         fileLines.forEach((lineContent, lineIndex) => {

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -136,6 +136,10 @@ export class Cache {
         const doc = Text.of(fileLines);
         const path = file.path;
 
+        if (!path.toLowerCase().endsWith(".md")) {
+            return;
+        }
+
         if (this.settings.ignoredDirectories) {
             for (let ignoredDirectory of this.settings.ignoredDirectories.split(
                 ",",

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -7,6 +7,7 @@ export interface MentionSettings {
     mentionStyleColor: string;
     meMentionName: string;
     meMentionStyleColor: string;
+    ignoredDirectories: string;
 }
 
 export const DEFAULT_SETTINGS: MentionSettings = {
@@ -14,6 +15,7 @@ export const DEFAULT_SETTINGS: MentionSettings = {
     mentionStyleColor: 'green',
     meMentionName: 'Me',
     meMentionStyleColor: 'deeppink',
+    ignoredDirectories: '',
 };
 
 export class MentionSettingsTab extends PluginSettingTab {
@@ -88,5 +90,20 @@ export class MentionSettingsTab extends PluginSettingTab {
                     this.plugin.saveSettings();
                 });
             });
+
+        new Setting(containerEl)
+        .setName('Ignored directories')
+        .setDesc('List of directories to ignore (separated by comma). Please reload Obsidian after changing this value.')
+        .addText((text) => {
+            text.setValue(this.plugin.settings.ignoredDirectories).onChange((value) => {
+                this.plugin.settings.ignoredDirectories = value;
+
+                if (value === '') {
+                    this.plugin.settings.ignoredDirectories = DEFAULT_SETTINGS.ignoredDirectories;
+                }
+
+                this.plugin.saveSettings();
+            });
+        });
     }
 }


### PR DESCRIPTION
Hi! 👋

I noticed the plugin indexing everything in my attachments' directory (including images and other file types).

I added a new setting to allow excluding directories from being indexed:

![](https://i.imgur.com/LauyvtM.png)

Thanks to not having to index binary blobs, everything is much faster now.